### PR TITLE
Feature Sequential Application of RAM_sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ RAM_sample(logtarget, x0, M0, n; opt_α=0.234, γ=2/3, q=Normal(), show_progress
 * `γ`: a parameter for the computation of the step size sequence.
 * `q`: the proposal distribution.
 * `show_progress`: a flag that controls whether a progress bar is shown.
+* `nsampled`: in sequential application of `RAM_sample`, provide the number of global steps so far to yield consistent updates on the covariance matrix.
 * `output_log_probability_x`: a flag that controls whether to include output for the log-posterior scores from each Markov chain iteration.
 
 The function returns a `NamedTuple` with three (or optionally four) elements:

--- a/src/RobustAdaptiveMetropolisSampler.jl
+++ b/src/RobustAdaptiveMetropolisSampler.jl
@@ -32,6 +32,7 @@ function RAM_sample(
         γ=2 / 3,
         q=Normal(),
         show_progress::Bool=true,
+        nsampled::Int=0,
         output_log_probability_x::Bool=false
     )
 
@@ -85,7 +86,9 @@ function RAM_sample(
         # Step R3
 
         # This is taken from the second paragraph of section 5
-        η = min(1, d * i^-γ)
+        # A sequential application of RAM_Sample requires knowledge on the number of already
+        # processed steps.
+        η = min(1, d * (nsampled + i)^-γ)
 
         # Compute the new covariance matrix
         M = s.L * (I + η * (α - opt_α) * (u * u') / norm(u)^2 ) * s.L'


### PR DESCRIPTION
It is not enough to feed `RAM_sample` with `x0=chain[end,:]` and `M0=Symmetric(M)` to provide an uninterrupted sampling experience. This shifts the step number in the calculation of scale on the new covariance matrix accordingly. BUT if applied, users need to keep track on the number of sampled themselves.